### PR TITLE
Upgrade apache jena dependency to 4.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use the parser directly, without the assistance of an RDF toolkit (a bold cho
 
 java-rdfa can be used from jena. Simply invoke:
 
-	Class.forName("net.rootdev.javardfa.RDFaReader");
+	Class.forName("net.rootdev.javardfa.jena.riot.RDFaReaderRIOT");
 
 Which will hook the two readers in to jena, then you will be able to:
 

--- a/rdfa-module/pom.xml
+++ b/rdfa-module/pom.xml
@@ -6,7 +6,7 @@
 	<packaging>bundle</packaging>
 	<version>1.0.0-BETA2-SNAPSHOT</version>
 	<properties>
-		<org.apache.jena.version>3.16.0</org.apache.jena.version>
+		<org.apache.jena.version>4.6.1</org.apache.jena.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<name>java-rdfa</name>

--- a/rdfa-module/src/main/java/net/rootdev/javardfa/jena/riot/RDFaLang.java
+++ b/rdfa-module/src/main/java/net/rootdev/javardfa/jena/riot/RDFaLang.java
@@ -1,0 +1,29 @@
+package net.rootdev.javardfa.jena.riot;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.jena.riot.Lang;
+
+/**
+ * @author Grigor Iliev <grigor@grigoriliev.com>
+ */
+public class RDFaLang extends Lang {
+	public static final RDFaLang HTML = new RDFaLang(
+		"HTML", "text/html", Collections.singletonList("html")
+	);
+	public static final RDFaLang XHTML = new RDFaLang(
+		"XHTML", "application/xhtml+xml", Arrays.asList("xhtml", "xht")
+	);
+
+	private RDFaLang(String langLabel, String mainContentType, List<String> fileExt) {
+		super(
+			langLabel,
+			mainContentType,
+			Collections.emptyList(),
+			Collections.emptyList(),
+			fileExt
+		);
+	}
+}

--- a/rdfa-module/src/main/java/net/rootdev/javardfa/jena/riot/RiotStatementSink.java
+++ b/rdfa-module/src/main/java/net/rootdev/javardfa/jena/riot/RiotStatementSink.java
@@ -1,0 +1,120 @@
+/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ * [See end of file]
+ */
+package net.rootdev.javardfa.jena.riot;
+
+import net.rootdev.javardfa.StatementSink;
+
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.riot.system.StreamRDF;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Damian Steer <pldms@mac.com>
+ * @author Grigor Iliev <grigor@grigoriliev.com>
+ */
+public class RiotStatementSink implements StatementSink {
+	private final StreamRDF outputStreamRDF;
+	private Map<String, Resource> bnodeLookup;
+
+	public RiotStatementSink(StreamRDF output) {
+		outputStreamRDF = output;
+	}
+
+	@Override public void setBase(String base) {
+		outputStreamRDF.base(base);
+	}
+
+	@Override
+	public void start() {
+		bnodeLookup = new HashMap<>();
+		outputStreamRDF.start();
+	}
+
+	@Override
+	public void end() {
+		outputStreamRDF.finish();
+		bnodeLookup = null;
+	}
+
+	@Override
+	public void addObject(String subject, String predicate, String object) {
+		outputStreamRDF.triple(
+			Triple.create(
+				getResource(subject).asNode(),
+				ResourceFactory.createProperty(predicate).asNode(),
+				getResource(object).asNode()
+			)
+		);
+	}
+
+	@Override
+	public void addLiteral(String subject, String predicate, String lex, String lang, String datatype) {
+		final Literal literal = datatype != null ?
+			ResourceFactory.createTypedLiteral(
+				lex, TypeMapper.getInstance().getSafeTypeByName(datatype)
+			) : lang != null ? ResourceFactory.createLangLiteral(lex, lang) :
+			ResourceFactory.createPlainLiteral(lex);
+		outputStreamRDF.triple(
+			Triple.create(
+				getResource(subject).asNode(),
+				ResourceFactory.createProperty(predicate).asNode(),
+				literal.asNode()
+			)
+		);
+	}
+
+	@Override
+	public void addPrefix(String prefix, String uri) {
+		outputStreamRDF.prefix(prefix, uri);
+	}
+
+	private Resource getResource(String res) {
+		if (res.startsWith("_:")) {
+			if (bnodeLookup.containsKey(res)) {
+				return bnodeLookup.get(res);
+			}
+			final Resource bnode = ResourceFactory.createResource(res);
+			bnodeLookup.put(res, bnode);
+			return bnode;
+		} else {
+			return ResourceFactory.createResource(res);
+		}
+	}
+}
+
+/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+

--- a/rdfa-module/src/main/java/rdfa/parse.java
+++ b/rdfa-module/src/main/java/rdfa/parse.java
@@ -27,7 +27,7 @@ public class parse {
         if ("--version".equals(args[0]) || "-v".equals(args[0])) version();
 
         // Ensure hooks run
-        Class.forName("net.rootdev.javardfa.RDFaReader");
+        Class.forName("net.rootdev.javardfa.jena.riot.RDFaReaderRIOT");
 
         String format = "XHTML";
         boolean getFormat = false;

--- a/rdfa-module/src/test/java/net/rootdev/javardfa/FileBasedTests.java
+++ b/rdfa-module/src/test/java/net/rootdev/javardfa/FileBasedTests.java
@@ -10,8 +10,8 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.algebra.Algebra;
-import org.apache.jena.util.FileManager;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -86,7 +86,7 @@ public class FileBasedTests {
         if (cf.matches("file:/[^/][^/].*")) cf = cf.replaceFirst("file:/", "file:///");
         String hf = htmlURL.toExternalForm();
         if (hf.matches("file:/[^/][^/].*")) hf = hf.replaceFirst("file:/", "file:///");
-        Model c = FileManager.get().loadModel(compareURL.toExternalForm());
+        Model c = RDFDataMgr.loadModel(compareURL.toExternalForm());
         Model m = ModelFactory.createDefaultModel();
         StatementSink sink = new JenaStatementSink(m);
         XMLReader parser = ParserFactory.createReaderForFormat(sink, Format.XHTML, Setting.OnePointOne);

--- a/rdfa-module/src/test/java/net/rootdev/javardfa/Scratch.java
+++ b/rdfa-module/src/test/java/net/rootdev/javardfa/Scratch.java
@@ -23,7 +23,6 @@ import net.rootdev.javardfa.output.OGPReader;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 /**
  *
@@ -50,7 +49,7 @@ public class Scratch {
 
         //XMLReader parser = ParserFactory.createReaderForFormat(new NTripleSink(System.out), Format.HTML);
         //parser.parse(Scratch.class.getResource("/simple.html").toExternalForm());
-        /*Class.forName(RDFaReader.class.getName());
+        /*Class.forName(net.rootdev.javardfa.jena.riot.RDFaReaderRIOT.class.getName());
         Model model = ModelFactory.createDefaultModel();
         //model.read("http://www.ivan-herman.net/foaf.html", "HTML");
         model.read("http://www.myspace.com/parishilton", "HTML");

--- a/rdfa-module/src/test/java/net/rootdev/javardfa/Scratch.java
+++ b/rdfa-module/src/test/java/net/rootdev/javardfa/Scratch.java
@@ -6,14 +6,13 @@
 package net.rootdev.javardfa;
 
 import net.rootdev.javardfa.jena.JenaStatementSink;
-import net.rootdev.javardfa.*;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.util.FileManager;
+import org.apache.jena.riot.system.stream.StreamManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
@@ -63,7 +62,7 @@ public class Scratch {
             throws SAXException, IOException {
         Model model = ModelFactory.createDefaultModel();
         StatementSink sink = new JenaStatementSink(model);
-        InputStream in = FileManager.get().open(testHTML);
+        InputStream in = StreamManager.get().open(testHTML);
 
         XMLReader reader = ParserFactory.createReaderForFormat(sink, format);
 

--- a/rdfa-module/src/test/java/net/rootdev/javardfa/conformance/RDFaConformance.java
+++ b/rdfa-module/src/test/java/net/rootdev/javardfa/conformance/RDFaConformance.java
@@ -13,7 +13,8 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.util.FileManager;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.system.stream.StreamManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -26,7 +27,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
@@ -46,9 +46,7 @@ public abstract class RDFaConformance {
 
         Set<String> toExclude = new HashSet(Arrays.asList(excludes));
 
-        FileManager fm = FileManager.get();
-
-        Model manifest = fm.loadModel(manifestURI);
+        Model manifest = RDFDataMgr.loadModel(manifestURI);
 
         Query manifestExtract = QueryFactory.read("manifest-extract.rq");
 
@@ -107,7 +105,7 @@ public abstract class RDFaConformance {
     @Test
     public void compare() throws SAXException, IOException {
         Model model = ModelFactory.createDefaultModel();
-        InputStream in = FileManager.get().open(input);
+        InputStream in = StreamManager.get().open(input);
         XMLReader reader = getParser(model);
         try {
             InputSource ins = new InputSource(in);

--- a/rdfa-module/src/test/java/net/rootdev/javardfa/conformance2/Cacher.java
+++ b/rdfa-module/src/test/java/net/rootdev/javardfa/conformance2/Cacher.java
@@ -3,8 +3,9 @@ package net.rootdev.javardfa.conformance2;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RIOT;
-import org.apache.jena.util.FileManager;
 import org.apache.jena.util.LocationMapper;
 
 import java.io.BufferedInputStream;
@@ -59,7 +60,7 @@ public class Cacher {
         }
         
         try {
-            Model manifest = FileManager.get().loadModel(uri, "TTL");
+            Model manifest = RDFDataMgr.loadModel(uri, Lang.TTL);
             
             NodeIterator ni = manifest.listObjects();
             // Download every object (bit broad?!)

--- a/rdfa-module/src/test/java/net/rootdev/javardfa/conformance2/RDFaConformance.java
+++ b/rdfa-module/src/test/java/net/rootdev/javardfa/conformance2/RDFaConformance.java
@@ -9,19 +9,19 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QueryParseException;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RIOT;
-import org.apache.jena.util.FileManager;
+import org.apache.jena.riot.system.stream.StreamManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +29,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,9 +60,7 @@ public abstract class RDFaConformance {
 
         Set<String> toExclude = new HashSet(Arrays.asList(excludes));
 
-        FileManager fm = FileManager.get();
-
-        Model manifest = fm.loadModel(manifestURI, "TTL");
+        Model manifest = RDFDataMgr.loadModel(manifestURI, Lang.TTL);
 
         Query manifestExtract = QueryFactory.read(extractQuery);
 
@@ -123,7 +120,7 @@ public abstract class RDFaConformance {
     public void compare() throws Throwable {
         try {
             Model model = ModelFactory.createDefaultModel();
-            InputStream in = FileManager.get().open(input);
+            InputStream in = StreamManager.get().open(input);
             XMLReader reader = getParser(model);
             InputSource ins = new InputSource(in);
             ins.setEncoding("utf-8");

--- a/sesame-module/src/test/java/net/rootdev/javardfa/SesameScratch.java
+++ b/sesame-module/src/test/java/net/rootdev/javardfa/SesameScratch.java
@@ -89,7 +89,7 @@ public class SesameScratch {
 
 
    private static RepositoryConnection test(String url, String mime) throws IOException, RDFParseException, RDFHandlerException, MalformedURLException, SailException, RepositoryException {
-//        Class.forName(RDFaReader.class.getName());
+//        Class.forName(net.rootdev.javardfa.jena.riot.RDFaReaderRIOT.class.getName());
 //        Model model = ModelFactory.createDefaultModel();
 //        model.read("http://www.ivan-herman.net/foaf.html", "HTML");
 //        System.err.println("== Read ==");


### PR DESCRIPTION
This is an initial support for using Apache Jena4 in java-rdfa.
Note that Jena requires Java 11. Thus, it might be worth considering creating a dedicated java-rdfa branch for Java 11+ development.